### PR TITLE
feat(docker): add ability to always download latest or specific docke…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,26 @@ LABEL "repository"="https://github.com/peaceiris/actions-hugo"
 LABEL "homepage"="https://github.com/peaceiris/actions-hugo"
 LABEL "maintainer"="peaceiris"
 
-ENV HUGO_VERSION='0.57.2'
-ENV HUGO_NAME="hugo_extended_${HUGO_VERSION}_Linux-64bit"
-ENV HUGO_URL="https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${HUGO_NAME}.tar.gz"
-RUN wget "${HUGO_URL}" && \
-    tar -zxvf "${HUGO_NAME}.tar.gz" && \
+ARG HUGO_VERSION="auto"
+RUN echo "Hugo version: ${HUGO_VERSION}"
+
+RUN if [ "$HUGO_VERSION" = "auto" ]; then \
+    echo "Using automated version detection" && \
+    curl -s https://api.github.com/repos/gohugoio/hugo/releases/latest | \
+    grep browser_download_url | \
+    cut -d '"' -f 4 | \
+    grep -e 'hugo_extended_.*_Linux.*\.tar\.gz' | \
+    xargs curl -fsSL -O; fi
+
+RUN if [ ! "$HUGO_VERSION" = "auto" ]; then \
+    echo "Using fixed version $HUGO_VERSION" && \
+    curl "https://api.github.com/repos/gohugoio/hugo/releases/tags/v${HUGO_VERSION}" | \
+    grep browser_download_url | \
+    cut -d '"' -f 4 | \
+    grep -e 'hugo_extended_.*_Linux.*\.tar\.gz' | \
+    xargs curl -fsSL -O; fi
+
+RUN cat *.gz | tar -xzvf - -i && \
     mv ./hugo /go/bin/
 
 ENTRYPOINT [ "/go/bin/hugo" ]


### PR DESCRIPTION
I created the PR we talked about. I think to specify the `--build-arg` flag that gets passed down to docker you need to have a config like this one:

```
name: github pages

on:
  push:
    branches:
    - master

jobs:
  build-deploy:
    runs-on: ubuntu-18.04
    steps:
    - uses: actions/checkout@master
    - name: build
      uses: peaceiris/actions-hugo@v0.57.2
	  args: --build-arg HUGO_VERSION='0.55.6'
      if: github.event.deleted == false
      with:
        args: --gc --minify --cleanDestinationDir
    - name: deploy
      uses: peaceiris/actions-gh-pages@v1.1.0
      if: success()
      env:
        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        PUBLISH_BRANCH: gh-pages
        PUBLISH_DIR: ./public
```

I am not sure though. As we defined the ENTRYPOINT to be hugo itself, we might not be able to pass arguments to docker itself.
Can you somehow check if the above works? I have no idea how to test Github Actions sorry.

Closes #15.