### PR TITLE
Release v0.58.0

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,6 +2,9 @@ name: Push workflow
 
 on:
   push:
+    branches:
+    - master
+    - 'release-v*'
     tags:
     - invalid-tag
 
@@ -11,7 +14,6 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Docker build and print Hugo version
-      if: github.event.deleted == false
       env:
         DOCKER_IMAGE: ${{ github.repository }}:${{ github.sha }}
       run: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,14 +5,13 @@ on:
     branches:
     - master
     - 'release-v*'
-    tags:
-    - invalid-tag
 
 jobs:
   test:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@master
+
     - name: Docker build and print Hugo version
       env:
         DOCKER_IMAGE: ${{ github.repository }}:${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL "repository"="https://github.com/peaceiris/actions-hugo"
 LABEL "homepage"="https://github.com/peaceiris/actions-hugo"
 LABEL "maintainer"="peaceiris"
 
-ENV HUGO_VERSION='0.57.2'
+ENV HUGO_VERSION='0.58.0'
 ENV HUGO_NAME="hugo_extended_${HUGO_VERSION}_Linux-64bit"
 ENV HUGO_URL="https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${HUGO_NAME}.tar.gz"
 RUN wget "${HUGO_URL}" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.7-buster
+FROM golang:1.13.0-buster
 
 LABEL "com.github.actions.name"="Hugo action"
 LABEL "com.github.actions.description"="GitHub Actions for Hugo extended and Hugo Modules"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: build
-      uses: peaceiris/actions-hugo@v0.57.2
+      uses: peaceiris/actions-hugo@v0.58.0
       if: github.event.deleted == false
       with:
         args: --gc --minify --cleanDestinationDir


### PR DESCRIPTION
- [x] upgrade: hugo to `v0.58.0`
- [x] update: tag on readme
- [x] upgrade: base image to `golang:1.13.0-buster`
- [ ] release: from **master** branch

cf.

- [Image Processing Galore! | Hugo v0.58.0](https://gohugo.io/news/0.58.0-relnotes/)
- [Hugo benchmarks: Go 1.12 vs Go 1.13 - Announcements - Hugo](https://discourse.gohugo.io/t/hugo-benchmarks-go-1-12-vs-go-1-13/20572)