### PR TITLE
ci: drop ubuntu-18.04, add ubuntu-22.04 and ubuntu-latest

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   CodeQL-Build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/dependency-review-action@v1

--- a/.github/workflows/dev-image.yml
+++ b/.github/workflows/dev-image.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   dev-image-test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - run: make build

--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   comment:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/purge-readme-image-cache.yml
+++ b/.github/workflows/purge-readme-image-cache.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   purge:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
 
     - run: >

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -11,8 +11,9 @@ jobs:
     strategy:
       matrix:
         os:
+          - 'ubuntu-22.04'
           - 'ubuntu-20.04'
-          - 'ubuntu-18.04'
+          - 'ubuntu-latest'
           - 'macos-latest'
           - 'windows-latest'
         hugo-version:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,9 @@ jobs:
     strategy:
       matrix:
         os:
+          - 'ubuntu-22.04'
           - 'ubuntu-20.04'
-          - 'ubuntu-18.04'
+          - 'ubuntu-latest'
           - 'macos-latest'
           - 'windows-latest'
     steps:
@@ -35,15 +36,15 @@ jobs:
       - run: npm ci
 
       - name: Run prettier
-        if: startsWith(matrix.os, 'ubuntu-18.04')
+        if: startsWith(matrix.os, 'ubuntu-22.04')
         run: npm run format:check
 
       - name: Run eslint
-        if: startsWith(matrix.os, 'ubuntu-18.04')
+        if: startsWith(matrix.os, 'ubuntu-22.04')
         run: npm run lint
 
       - name: Run ncc
-        if: startsWith(matrix.os, 'ubuntu-18.04')
+        if: startsWith(matrix.os, 'ubuntu-22.04')
         run: npm run build
 
       - run: npm test

--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   update:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ We no longer build or pull a Hugo docker image.
 Thanks to this change, we can complete this action in less than a few seconds.
 (A docker base action was taking about 1 min or more execution time to build and pull a docker image.)
 
-| OS (runs-on) | ubuntu-18.04, ubuntu-20.04 | macos-latest | windows-2019 |
+| OS (runs-on) | ubuntu-latest, ubuntu-20.04, ubuntu-22.04 | macos-latest | windows-2019 |
 |---|:---:|:---:|:---:|
 | Support | ✅️ | ✅️ | ✅️ |
 
@@ -80,7 +80,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
@@ -245,7 +245,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
@@ -300,7 +300,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
@@ -352,7 +352,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:


### PR DESCRIPTION
add support for ubuntu 22.04


- [starting with 8 of August 2022 support for ubuntu 18.04 is deprecated](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/)
- [ubuntu 22.04 is generally available](https://github.blog/changelog/2022-08-09-github-actions-ubuntu-22-04-is-now-generally-available-on-github-hosted-runners/)