### PR TITLE
docs: bump ruby version to 3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.2
 
       - run: gem install asciidoctor
 


### PR DESCRIPTION
On a second glance, I spotted another minor issue: repo for docsy hugo theme renamed branch `master` to `main`, this PR reflects this.