### PR TITLE
fix(doc): Update `@v2` to `@v3` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ jobs:
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v3
         with:
           hugo-version: '0.119.0'
           # extended: true
@@ -121,7 +121,7 @@ Set `extended: true` to use a Hugo extended version.
 
 ```yaml
 - name: Setup Hugo
-  uses: peaceiris/actions-hugo@v2
+  uses: peaceiris/actions-hugo@v3
   with:
     hugo-version: '0.119.0'
     extended: true
@@ -133,7 +133,7 @@ Set `hugo-version: 'latest'` to use the latest version of Hugo.
 
 ```yaml
 - name: Setup Hugo
-  uses: peaceiris/actions-hugo@v2
+  uses: peaceiris/actions-hugo@v3
   with:
     hugo-version: 'latest'
 ```
@@ -190,7 +190,7 @@ Next, add a step to read a Hugo version from the `.env` file.
         echo "HUGO_VERSION=${HUGO_VERSION}" >> "${GITHUB_OUTPUT}"
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
         hugo-version: '${{ steps.hugo-version.outputs.HUGO_VERSION }}'
         extended: true
@@ -256,7 +256,7 @@ jobs:
           fetch-depth: 0         # Fetch all history for .GitInfo and .Lastmod
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v3
         with:
           hugo-version: '0.119.0'
           extended: true
@@ -310,7 +310,7 @@ jobs:
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v3
         with:
           hugo-version: '0.119.0'
           extended: true
@@ -364,7 +364,7 @@ jobs:
         run: git config core.quotePath false
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v3
         with:
           hugo-version: '0.119.0'
 ```


### PR DESCRIPTION
This action's major version was bumped a few days ago. However the versions in the README.md are still v2.

Since README.md is a primary document of this action, many people would copy&paste the configuration example. Updating the versions in them is important.