### PR TITLE
docs: add env.HUGO_CACHEDIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,13 +151,27 @@ This action fetches the latest version of Hugo by [hugo | Homebrew Formulae](htt
 ### ⭐️ Caching Hugo Modules
 
 Insert a cache step before site-building as follows.
-Note that with latest hugo version, the [cache dir location](https://gohugo.io/getting-started/configuration/#configure-cachedir) on a Linux-based operating system is `${HOME}/.cache`. On macOS, `${HOME}/Library/Caches` has the location.
+
+First, to maximize compatibility with all Hugo versions, let's define the variable `HUGO_CACHEDIR`:
+
+```yaml
+# * ...
+
+jobs:
+  deploy:
+    runs-on: ubuntu-22.04
+    env:
+      HUGO_CACHEDIR: /tmp/hugo_cache # <- Define the env variable here, so that Hugo's cache dir is now predictible in your workflow and doesn't depend on the Hugo's version you're using.
+
+# * ...
+```
+
+Now, let's add the cache action call just above the _Build_ step:
 
 ```yaml
 - uses: actions/cache@v4
   with:
-    path: /home/runner/.cache/hugo_cache    # <-- with hugo version v0.116.0 and above
-    # path: /tmp/hugo_cache                 # <-- with hugo version < v0.116.0
+    path: ${{ env.HUGO_CACHEDIR }} # <- Use the same env variable just right here
     key: ${{ runner.os }}-hugomod-${{ hashFiles('**/go.sum') }}
     restore-keys: |
       ${{ runner.os }}-hugomod-

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "actions-hugo",
-      "version": "2.6.0",
+      "version": "3.0.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Fixes https://github.com/peaceiris/actions-gh-pages/issues/1081

Also, notice that the version of the package was stale in the _package-lock.json_ file. It has been fixed automatically when I ran `npm install`.

By the way, this PR is related to:
- https://github.com/peaceiris/actions-hugo/pull/646

:arrow_up: We're also discussing some edge cases with @razonyang on this related PR comments.
I might do some changes. (As you want!)