### PR TITLE
fix: Hugo package naming fix

### DIFF
--- a/__tests__/get-arch.test.ts
+++ b/__tests__/get-arch.test.ts
@@ -54,10 +54,10 @@ describe('getArch', () => {
   test('exception', () => {
     expect(() => {
       getArch('mips', 'linux', '0.101.0');
-    }).toThrowError('mips is not supported');
+    }).toThrow('mips is not supported');
 
     expect(() => {
       getArch('arm', 'linux', '0.102.0')
-    }).toThrowError('arm is not supported');
+    }).toThrow('arm is not supported');
   });
 });

--- a/__tests__/get-arch.test.ts
+++ b/__tests__/get-arch.test.ts
@@ -1,63 +1,123 @@
 import getArch from '../src/get-arch';
 
 describe('getArch', () => {
-  test('processor architecture < 0.102.0', () => {
-    expect(getArch('x64', 'linux', '0.101.0')).toBe('64bit');
-    expect(getArch('x64', 'macOS', '0.101.0')).toBe('64bit');
-    expect(getArch('x64', 'windows', '0.101.0')).toBe('64bit');
-
-    expect(getArch('arm', 'linux', '0.101.0')).toBe('ARM');
-    expect(getArch('arm', 'macOS', '0.101.0')).toBe('ARM');
-    expect(getArch('arm', 'windows', '0.101.0')).toBe('ARM');
-
-    expect(getArch('arm64', 'linux', '0.101.0')).toBe('ARM64');
-    expect(getArch('arm64', 'macOS', '0.101.0')).toBe('ARM64');
-    expect(getArch('arm64', 'windows', '0.101.0')).toBe('ARM64');
+  const groups = [
+    {
+      condition: 'when hugo version < 0.102.0',
+      conventions: {
+        arch: {
+          darwinUniversal: false,
+          dropped32BitSupport: false,
+          standardizedNaming: false
+        },
+        os: {
+          renamedMacOS: false,
+          downcasedAll: false
+        }
+      },
+      tests: [
+        {arch: 'x64', os: 'linux', expected: '64bit'},
+        {arch: 'x64', os: 'macOS', expected: '64bit'},
+        {arch: 'x64', os: 'windows', expected: '64bit'},
+        {arch: 'arm', os: 'linux', expected: 'ARM'},
+        {arch: 'arm', os: 'macOS', expected: 'ARM'},
+        {arch: 'arm', os: 'windows', expected: 'ARM'},
+        {arch: 'arm64', os: 'linux', expected: 'ARM64'},
+        {arch: 'arm64', os: 'macOS', expected: 'ARM64'},
+        {arch: 'arm64', os: 'windows', expected: 'ARM64'}
+      ]
+    },
+    {
+      condition: 'when hugo version === 0.102.z',
+      conventions: {
+        arch: {
+          darwinUniversal: true,
+          dropped32BitSupport: true,
+          standardizedNaming: false
+        },
+        os: {
+          renamedMacOS: true,
+          downcasedAll: false
+        }
+      },
+      tests: [
+        {arch: 'x64', os: 'linux', expected: '64bit'},
+        {arch: 'x64', os: 'macOS', expected: 'universal'},
+        {arch: 'x64', os: 'windows', expected: '64bit'},
+        {arch: 'arm', os: 'linux', throws: true},
+        {arch: 'arm', os: 'macOS', expected: 'universal'},
+        {arch: 'arm', os: 'windows', throws: true},
+        {arch: 'arm64', os: 'linux', expected: 'ARM64'},
+        {arch: 'arm64', os: 'macOS', expected: 'universal'},
+        {arch: 'arm64', os: 'windows', expected: 'ARM64'}
+      ]
+    },
+    {
+      condition: 'when hugo version >= 0.103.0',
+      conventions: {
+        arch: {
+          darwinUniversal: true,
+          dropped32BitSupport: true,
+          standardizedNaming: true
+        },
+        os: {
+          renamedMacOS: true,
+          downcasedAll: true
+        }
+      },
+      tests: [
+        {arch: 'x64', os: 'linux', expected: 'amd64'},
+        {arch: 'x64', os: 'macOS', expected: 'universal'},
+        {arch: 'x64', os: 'windows', expected: 'amd64'},
+        {arch: 'arm', os: 'linux', throws: true},
+        {arch: 'arm', os: 'macOS', expected: 'universal'},
+        {arch: 'arm', os: 'windows', throws: true},
+        {arch: 'arm64', os: 'linux', expected: 'arm64'},
+        {arch: 'arm64', os: 'macOS', expected: 'universal'},
+        {arch: 'arm64', os: 'windows', expected: 'arm64'}
+      ]
+    },
+    {
+      condition: 'when the architecture is unsupported for the action',
+      conventions: {
+        arch: {
+          darwinUniversal: false,
+          dropped32BitSupport: false,
+          standardizedNaming: false
+        },
+        os: {
+          renamedMacOS: false,
+          downcasedAll: false
+        }
+      },
+      tests: [{arch: 'mips', os: 'linux', throws: true}]
+    }
+  ].map(function (group) {
+    group.tests = group.tests.map(function (example) {
+      return Object.assign(example, {
+        toString: function () {
+          let name = `${example.os} on ${example.arch} `;
+          name += example?.throws ? 'throws as not supported' : `returns ${example.expected}`;
+          return name;
+        }
+      });
+    });
+    return Object.assign(group, {
+      toString: function () {
+        return group.condition;
+      }
+    });
   });
 
-  test('processor architecture === 0.102.z', () => {
-    expect(getArch('x64', 'linux', '0.102.0')).toBe('64bit');
-    expect(getArch('x64', 'macOS', '0.102.0')).toBe('universal');
-    expect(getArch('x64', 'windows', '0.102.0')).toBe('64bit');
-
-    expect(getArch('arm', 'macOS', '0.102.0')).toBe('universal');
-
-    expect(getArch('arm64', 'linux', '0.102.0')).toBe('ARM64');
-    expect(getArch('arm64', 'macOS', '0.102.0')).toBe('universal');
-    expect(getArch('arm64', 'windows', '0.102.0')).toBe('ARM64');
-  });
-
-  test('processor architecture === 0.103.z', () => {
-    expect(getArch('x64', 'linux', '0.103.0')).toBe('amd64');
-    expect(getArch('x64', 'darwin', '0.103.0')).toBe('universal');
-    expect(getArch('x64', 'windows', '0.103.0')).toBe('amd64');
-
-    expect(getArch('arm', 'darwin', '0.103.0')).toBe('universal');
-
-    expect(getArch('arm64', 'linux', '0.103.0')).toBe('arm64');
-    expect(getArch('arm64', 'darwin', '0.103.0')).toBe('universal');
-    expect(getArch('arm64', 'windows', '0.103.0')).toBe('arm64');
-  });
-
-  test('processor architecture > 0.103.0', () => {
-    expect(getArch('x64', 'linux', '0.104.0')).toBe('amd64');
-    expect(getArch('x64', 'darwin', '0.104.0')).toBe('universal');
-    expect(getArch('x64', 'windows', '0.104.0')).toBe('amd64');
-
-    expect(getArch('arm', 'darwin', '0.104.0')).toBe('universal');
-
-    expect(getArch('arm64', 'linux', '0.104.0')).toBe('arm64');
-    expect(getArch('arm64', 'darwin', '0.104.0')).toBe('universal');
-    expect(getArch('arm64', 'windows', '0.104.0')).toBe('arm64');
-  });
-
-  test('exception', () => {
-    expect(() => {
-      getArch('mips', 'linux', '0.101.0');
-    }).toThrow('mips is not supported');
-
-    expect(() => {
-      getArch('arm', 'linux', '0.102.0')
-    }).toThrow('arm is not supported');
+  describe.each(groups)('%s', ({conventions, tests}) => {
+    test.each(tests)('%s', ({arch, os, throws, expected}) => {
+      if (throws) {
+        expect(() => {
+          getArch(arch, os, conventions);
+        }).toThrow(`${arch} is not supported`);
+      } else {
+        expect(getArch(arch, os, conventions)).toBe(expected);
+      }
+    });
   });
 });

--- a/__tests__/get-arch.test.ts
+++ b/__tests__/get-arch.test.ts
@@ -17,12 +17,15 @@ describe('getArch', () => {
       },
       tests: [
         {arch: 'x64', os: 'linux', expected: '64bit'},
+        {arch: 'x64', os: 'darwin', expected: '64bit'},
         {arch: 'x64', os: 'macOS', expected: '64bit'},
         {arch: 'x64', os: 'windows', expected: '64bit'},
         {arch: 'arm', os: 'linux', expected: 'ARM'},
+        {arch: 'arm', os: 'darwin', expected: 'ARM'},
         {arch: 'arm', os: 'macOS', expected: 'ARM'},
         {arch: 'arm', os: 'windows', expected: 'ARM'},
         {arch: 'arm64', os: 'linux', expected: 'ARM64'},
+        {arch: 'arm64', os: 'darwin', expected: 'ARM64'},
         {arch: 'arm64', os: 'macOS', expected: 'ARM64'},
         {arch: 'arm64', os: 'windows', expected: 'ARM64'}
       ]

--- a/__tests__/get-arch.test.ts
+++ b/__tests__/get-arch.test.ts
@@ -1,15 +1,63 @@
 import getArch from '../src/get-arch';
 
 describe('getArch', () => {
-  test('processor architecture', () => {
-    expect(getArch('x64')).toBe('64bit');
-    expect(getArch('arm')).toBe('ARM');
-    expect(getArch('arm64')).toBe('ARM64');
+  test('processor architecture < 0.102.0', () => {
+    expect(getArch('x64', 'linux', '0.101.0')).toBe('64bit');
+    expect(getArch('x64', 'macOS', '0.101.0')).toBe('64bit');
+    expect(getArch('x64', 'windows', '0.101.0')).toBe('64bit');
+
+    expect(getArch('arm', 'linux', '0.101.0')).toBe('ARM');
+    expect(getArch('arm', 'macOS', '0.101.0')).toBe('ARM');
+    expect(getArch('arm', 'windows', '0.101.0')).toBe('ARM');
+
+    expect(getArch('arm64', 'linux', '0.101.0')).toBe('ARM64');
+    expect(getArch('arm64', 'macOS', '0.101.0')).toBe('ARM64');
+    expect(getArch('arm64', 'windows', '0.101.0')).toBe('ARM64');
+  });
+
+  test('processor architecture === 0.102.z', () => {
+    expect(getArch('x64', 'linux', '0.102.0')).toBe('64bit');
+    expect(getArch('x64', 'macOS', '0.102.0')).toBe('universal');
+    expect(getArch('x64', 'windows', '0.102.0')).toBe('64bit');
+
+    expect(getArch('arm', 'macOS', '0.102.0')).toBe('universal');
+
+    expect(getArch('arm64', 'linux', '0.102.0')).toBe('ARM64');
+    expect(getArch('arm64', 'macOS', '0.102.0')).toBe('universal');
+    expect(getArch('arm64', 'windows', '0.102.0')).toBe('ARM64');
+  });
+
+  test('processor architecture === 0.103.z', () => {
+    expect(getArch('x64', 'linux', '0.103.0')).toBe('amd64');
+    expect(getArch('x64', 'darwin', '0.103.0')).toBe('universal');
+    expect(getArch('x64', 'windows', '0.103.0')).toBe('amd64');
+
+    expect(getArch('arm', 'darwin', '0.103.0')).toBe('universal');
+
+    expect(getArch('arm64', 'linux', '0.103.0')).toBe('arm64');
+    expect(getArch('arm64', 'darwin', '0.103.0')).toBe('universal');
+    expect(getArch('arm64', 'windows', '0.103.0')).toBe('arm64');
+  });
+
+  test('processor architecture > 0.103.0', () => {
+    expect(getArch('x64', 'linux', '0.104.0')).toBe('amd64');
+    expect(getArch('x64', 'darwin', '0.104.0')).toBe('universal');
+    expect(getArch('x64', 'windows', '0.104.0')).toBe('amd64');
+
+    expect(getArch('arm', 'darwin', '0.104.0')).toBe('universal');
+
+    expect(getArch('arm64', 'linux', '0.104.0')).toBe('arm64');
+    expect(getArch('arm64', 'darwin', '0.104.0')).toBe('universal');
+    expect(getArch('arm64', 'windows', '0.104.0')).toBe('arm64');
   });
 
   test('exception', () => {
     expect(() => {
-      getArch('mips');
-    }).toThrow('mips is not supported');
+      getArch('mips', 'linux', '0.101.0');
+    }).toThrowError('mips is not supported');
+
+    expect(() => {
+      getArch('arm', 'linux', '0.102.0')
+    }).toThrowError('arm is not supported');
   });
 });

--- a/__tests__/get-arch.test.ts
+++ b/__tests__/get-arch.test.ts
@@ -7,7 +7,7 @@ describe('getArch', () => {
       conventions: {
         arch: {
           darwinUniversal: false,
-          dropped32BitSupport: false,
+          droppedWindowsArmSupport: false,
           standardizedNaming: false
         },
         os: {
@@ -32,7 +32,7 @@ describe('getArch', () => {
       conventions: {
         arch: {
           darwinUniversal: true,
-          dropped32BitSupport: true,
+          droppedWindowsArmSupport: true,
           standardizedNaming: false
         },
         os: {
@@ -44,7 +44,7 @@ describe('getArch', () => {
         {arch: 'x64', os: 'linux', expected: '64bit'},
         {arch: 'x64', os: 'macOS', expected: 'universal'},
         {arch: 'x64', os: 'windows', expected: '64bit'},
-        {arch: 'arm', os: 'linux', throws: true},
+        {arch: 'arm', os: 'linux', expected: 'ARM'},
         {arch: 'arm', os: 'macOS', expected: 'universal'},
         {arch: 'arm', os: 'windows', throws: true},
         {arch: 'arm64', os: 'linux', expected: 'ARM64'},
@@ -57,7 +57,7 @@ describe('getArch', () => {
       conventions: {
         arch: {
           darwinUniversal: true,
-          dropped32BitSupport: true,
+          droppedWindowsArmSupport: true,
           standardizedNaming: true
         },
         os: {
@@ -69,7 +69,7 @@ describe('getArch', () => {
         {arch: 'x64', os: 'linux', expected: 'amd64'},
         {arch: 'x64', os: 'macOS', expected: 'universal'},
         {arch: 'x64', os: 'windows', expected: 'amd64'},
-        {arch: 'arm', os: 'linux', throws: true},
+        {arch: 'arm', os: 'linux', expected: 'arm'},
         {arch: 'arm', os: 'macOS', expected: 'universal'},
         {arch: 'arm', os: 'windows', throws: true},
         {arch: 'arm64', os: 'linux', expected: 'arm64'},
@@ -82,7 +82,7 @@ describe('getArch', () => {
       conventions: {
         arch: {
           darwinUniversal: false,
-          dropped32BitSupport: false,
+          droppedWindowsArmSupport: false,
           standardizedNaming: false
         },
         os: {

--- a/__tests__/get-arch.test.ts
+++ b/__tests__/get-arch.test.ts
@@ -36,7 +36,7 @@ describe('getArch', () => {
           standardizedNaming: false
         },
         os: {
-          renamedMacOS: true,
+          renamedMacOS: false,
           downcasedAll: false
         }
       },
@@ -92,32 +92,41 @@ describe('getArch', () => {
       },
       tests: [{arch: 'mips', os: 'linux', throws: true}]
     }
-  ].map(function (group) {
-    group.tests = group.tests.map(function (example) {
-      return Object.assign(example, {
-        toString: function () {
-          let name = `${example.os} on ${example.arch} `;
-          name += example?.throws ? 'throws as not supported' : `returns ${example.expected}`;
-          return name;
-        }
-      });
-    });
-    return Object.assign(group, {
-      toString: function () {
-        return group.condition;
-      }
-    });
-  });
+  ];
 
-  describe.each(groups)('%s', ({conventions, tests}) => {
-    test.each(tests)('%s', ({arch, os, throws, expected}) => {
-      if (throws) {
-        expect(() => {
-          getArch(arch, os, conventions);
-        }).toThrow(`${arch} is not supported`);
-      } else {
-        expect(getArch(arch, os, conventions)).toBe(expected);
-      }
-    });
-  });
+  const passingTests = groups.flatMap(group =>
+    group.tests
+      .filter(example => !example.throws)
+      .map(example => ({
+        ...example,
+        condition: group.condition,
+        conventions: group.conventions
+      }))
+  );
+
+  const throwingTests = groups.flatMap(group =>
+    group.tests
+      .filter(example => example.throws)
+      .map(example => ({
+        ...example,
+        condition: group.condition,
+        conventions: group.conventions
+      }))
+  );
+
+  test.each(passingTests)(
+    '$condition: $os on $arch returns $expected',
+    ({arch, os, conventions, expected}) => {
+      expect(getArch(arch, os, conventions)).toBe(expected);
+    }
+  );
+
+  test.each(throwingTests)(
+    '$condition: $os on $arch throws as not supported',
+    ({arch, os, conventions}) => {
+      expect(() => {
+        getArch(arch, os, conventions);
+      }).toThrow(`${arch} is not supported`);
+    }
+  );
 });

--- a/__tests__/get-conventions.test.ts
+++ b/__tests__/get-conventions.test.ts
@@ -1,0 +1,61 @@
+import getConventions from '../src/get-conventions';
+
+describe('getConventions()', () => {
+  const groups = [
+    {
+      condition: 'when hugo version < 0.102.0',
+      version: '0.101.0',
+      expected: {
+        arch: {
+          darwinUniversal: false,
+          dropped32BitSupport: false,
+          standardizedNaming: false
+        },
+        os: {
+          renamedMacOS: false,
+          downcasedAll: false
+        }
+      }
+    },
+    {
+      condition: 'when hugo version === 0.102.z',
+      version: '0.102.0',
+      expected: {
+        arch: {
+          darwinUniversal: true,
+          dropped32BitSupport: true,
+          standardizedNaming: false
+        },
+        os: {
+          renamedMacOS: true,
+          downcasedAll: false
+        }
+      }
+    },
+    {
+      condition: 'when hugo version >= 0.103.0',
+      version: '0.103.0',
+      expected: {
+        arch: {
+          darwinUniversal: true,
+          dropped32BitSupport: true,
+          standardizedNaming: true
+        },
+        os: {
+          renamedMacOS: true,
+          downcasedAll: true
+        }
+      }
+    }
+  ].map(function (group) {
+    return Object.assign(group, {
+      toString: function () {
+        return group.condition;
+      }
+    });
+  });
+
+  test.each(groups)('%s', ({expected, version}) => {
+    expect(getConventions(version)).toEqual(expected);
+  });
+});

--- a/__tests__/get-conventions.test.ts
+++ b/__tests__/get-conventions.test.ts
@@ -1,4 +1,4 @@
-import getConventions from '../src/get-conventions';
+import {getConventions} from '../src/get-conventions';
 
 describe('getConventions()', () => {
   const groups = [

--- a/__tests__/get-conventions.test.ts
+++ b/__tests__/get-conventions.test.ts
@@ -8,7 +8,7 @@ describe('getConventions()', () => {
       expected: {
         arch: {
           darwinUniversal: false,
-          dropped32BitSupport: false,
+          droppedWindowsArmSupport: false,
           standardizedNaming: false
         },
         os: {
@@ -23,11 +23,11 @@ describe('getConventions()', () => {
       expected: {
         arch: {
           darwinUniversal: true,
-          dropped32BitSupport: true,
+          droppedWindowsArmSupport: true,
           standardizedNaming: false
         },
         os: {
-          renamedMacOS: true,
+          renamedMacOS: false,
           downcasedAll: false
         }
       }
@@ -38,7 +38,7 @@ describe('getConventions()', () => {
       expected: {
         arch: {
           darwinUniversal: true,
-          dropped32BitSupport: true,
+          droppedWindowsArmSupport: true,
           standardizedNaming: true
         },
         os: {

--- a/__tests__/get-latest-version.test.ts
+++ b/__tests__/get-latest-version.test.ts
@@ -1,6 +1,6 @@
 import {getURL, getLatestVersion} from '../src/get-latest-version';
-import nock from 'nock';
 import {FetchError} from 'node-fetch';
+import {clearMockFetchResponses, mockFetchResponse} from './mocks/node-fetch';
 import {Tool} from '../src/constants';
 import jsonTestBrew from './data/brew.json';
 import jsonTestGithub from './data/github.json';
@@ -10,7 +10,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  nock.cleanAll();
+  clearMockFetchResponses();
 });
 
 describe('getURL()', () => {
@@ -27,23 +27,25 @@ describe('getURL()', () => {
 
 describe('getLatestVersion()', () => {
   test('return latest version via brew', async () => {
-    nock('https://formulae.brew.sh').get(`/api/formula/${Tool.Repo}.json`).reply(200, jsonTestBrew);
+    mockFetchResponse(`https://formulae.brew.sh/api/formula/${Tool.Repo}.json`, 200, jsonTestBrew);
 
     const versionLatest: string = await getLatestVersion(Tool.Org, Tool.Repo, 'brew');
     expect(versionLatest).toMatch(Tool.TestVersionLatest);
   });
 
   test('return latest version via GitHub', async () => {
-    nock('https://api.github.com')
-      .get(`/repos/${Tool.Org}/${Tool.Repo}/releases/latest`)
-      .reply(200, jsonTestGithub);
+    mockFetchResponse(
+      `https://api.github.com/repos/${Tool.Org}/${Tool.Repo}/releases/latest`,
+      200,
+      jsonTestGithub
+    );
 
     const versionLatest: string = await getLatestVersion(Tool.Org, Tool.Repo, 'github');
     expect(versionLatest).toMatch(Tool.TestVersionLatest);
   });
 
   test('return exception 404', async () => {
-    nock('https://formulae.brew.sh').get(`/api/formula/${Tool.Repo}.json`).reply(404);
+    mockFetchResponse(`https://formulae.brew.sh/api/formula/${Tool.Repo}.json`, 404);
 
     await expect(getLatestVersion(Tool.Org, Tool.Repo, 'brew')).rejects.toThrow(FetchError);
   });

--- a/__tests__/get-os.test.ts
+++ b/__tests__/get-os.test.ts
@@ -22,6 +22,6 @@ describe('getOS', () => {
   test('exception', () => {
     expect(() => {
       getOS('centos', '0.101.0');
-    }).toThrowError('centos is not supported');
+    }).toThrow('centos is not supported');
   });
 });

--- a/__tests__/get-os.test.ts
+++ b/__tests__/get-os.test.ts
@@ -1,27 +1,100 @@
 import getOS from '../src/get-os';
 
 describe('getOS', () => {
-  test('os type', () => {
-    expect(getOS('linux', '0.101.0')).toBe('Linux');
-    expect(getOS('darwin', '0.101.0')).toBe('macOS');
-    expect(getOS('win32', '0.101.0')).toBe('Windows');
+  const groups = [
+    {
+      condition: 'when hugo version < 0.102.0',
+      conventions: {
+        arch: {
+          darwinUniversal: false,
+          dropped32BitSupport: false,
+          standardizedNaming: false
+        },
+        os: {
+          renamedMacOS: false,
+          downcasedAll: false
+        }
+      },
+      tests: [
+        {os: 'linux', expected: 'Linux'},
+        {os: 'darwin', expected: 'macOS'},
+        {os: 'win32', expected: 'Windows'}
+      ]
+    },
+    {
+      condition: 'when hugo version === 0.102.z',
+      conventions: {
+        arch: {
+          darwinUniversal: true,
+          dropped32BitSupport: true,
+          standardizedNaming: false
+        },
+        os: {
+          renamedMacOS: true,
+          downcasedAll: false
+        }
+      },
+      tests: [
+        {os: 'linux', expected: 'Linux'},
+        {os: 'darwin', expected: 'darwin'},
+        {os: 'win32', expected: 'Windows'}
+      ]
+    },
+    {
+      condition: 'when hugo version >= 0.103.0',
+      conventions: {
+        arch: {
+          darwinUniversal: true,
+          dropped32BitSupport: true,
+          standardizedNaming: true
+        },
+        os: {
+          renamedMacOS: true,
+          downcasedAll: true
+        }
+      },
+      tests: [
+        {os: 'linux', expected: 'linux'},
+        {os: 'darwin', expected: 'darwin'},
+        {os: 'win32', expected: 'windows'}
+      ]
+    }
+  ].map(function (group) {
+    group.tests = group.tests.map(function (example) {
+      return Object.assign(example, {
+        toString: function () {
+          return `${example.os} returns ${example.expected}`;
+        }
+      });
+    });
+    return Object.assign(group, {
+      toString: function () {
+        return group.condition;
+      }
+    });
+  });
 
-    expect(getOS('linux', '0.102.0')).toBe('Linux');
-    expect(getOS('darwin', '0.102.0')).toBe('darwin');
-    expect(getOS('win32', '0.102.0')).toBe('Windows');
-
-    expect(getOS('linux', '0.103.0')).toBe('linux');
-    expect(getOS('darwin', '0.103.0')).toBe('darwin');
-    expect(getOS('win32', '0.103.0')).toBe('windows');
-
-    expect(getOS('linux', '0.104.0')).toBe('linux');
-    expect(getOS('darwin', '0.104.0')).toBe('darwin');
-    expect(getOS('win32', '0.104.0')).toBe('windows');
+  describe.each(groups)('%s', ({conventions, tests}) => {
+    test.each(tests)('%s', ({os, expected}) => {
+      expect(getOS(os, conventions)).toBe(expected);
+    });
   });
 
   test('exception', () => {
+    const conventions = {
+      arch: {
+        darwinUniversal: false,
+        dropped32BitSupport: false,
+        standardizedNaming: false
+      },
+      os: {
+        renamedMacOS: false,
+        downcasedAll: false
+      }
+    };
+
     expect(() => {
-      getOS('centos', '0.101.0');
+      getOS('centos', conventions);
     }).toThrow('centos is not supported');
   });
 });

--- a/__tests__/get-os.test.ts
+++ b/__tests__/get-os.test.ts
@@ -2,14 +2,26 @@ import getOS from '../src/get-os';
 
 describe('getOS', () => {
   test('os type', () => {
-    expect(getOS('linux')).toBe('Linux');
-    expect(getOS('darwin')).toBe('macOS');
-    expect(getOS('win32')).toBe('Windows');
+    expect(getOS('linux', '0.101.0')).toBe('Linux');
+    expect(getOS('darwin', '0.101.0')).toBe('macOS');
+    expect(getOS('win32', '0.101.0')).toBe('Windows');
+
+    expect(getOS('linux', '0.102.0')).toBe('Linux');
+    expect(getOS('darwin', '0.102.0')).toBe('darwin');
+    expect(getOS('win32', '0.102.0')).toBe('Windows');
+
+    expect(getOS('linux', '0.103.0')).toBe('linux');
+    expect(getOS('darwin', '0.103.0')).toBe('darwin');
+    expect(getOS('win32', '0.103.0')).toBe('windows');
+
+    expect(getOS('linux', '0.104.0')).toBe('linux');
+    expect(getOS('darwin', '0.104.0')).toBe('darwin');
+    expect(getOS('win32', '0.104.0')).toBe('windows');
   });
 
   test('exception', () => {
     expect(() => {
-      getOS('centos');
-    }).toThrow('centos is not supported');
+      getOS('centos', '0.101.0');
+    }).toThrowError('centos is not supported');
   });
 });

--- a/__tests__/get-os.test.ts
+++ b/__tests__/get-os.test.ts
@@ -7,7 +7,7 @@ describe('getOS', () => {
       conventions: {
         arch: {
           darwinUniversal: false,
-          dropped32BitSupport: false,
+          droppedWindowsArmSupport: false,
           standardizedNaming: false
         },
         os: {
@@ -26,17 +26,17 @@ describe('getOS', () => {
       conventions: {
         arch: {
           darwinUniversal: true,
-          dropped32BitSupport: true,
+          droppedWindowsArmSupport: true,
           standardizedNaming: false
         },
         os: {
-          renamedMacOS: true,
+          renamedMacOS: false,
           downcasedAll: false
         }
       },
       tests: [
         {os: 'linux', expected: 'Linux'},
-        {os: 'darwin', expected: 'darwin'},
+        {os: 'darwin', expected: 'macOS'},
         {os: 'win32', expected: 'Windows'}
       ]
     },
@@ -45,7 +45,7 @@ describe('getOS', () => {
       conventions: {
         arch: {
           darwinUniversal: true,
-          dropped32BitSupport: true,
+          droppedWindowsArmSupport: true,
           standardizedNaming: true
         },
         os: {
@@ -84,7 +84,7 @@ describe('getOS', () => {
     const conventions = {
       arch: {
         darwinUniversal: false,
-        dropped32BitSupport: false,
+        droppedWindowsArmSupport: false,
         standardizedNaming: false
       },
       os: {

--- a/__tests__/get-url.test.ts
+++ b/__tests__/get-url.test.ts
@@ -49,6 +49,32 @@ describe('getURL()', () => {
     ]);
   });
 
+  test('get URLs to macOS 0.102 universal assets', () => {
+    const baseURL = 'https://github.com/gohugoio/hugo/releases/download/v0.102.0';
+    expect(getURL('macOS', 'universal', 'false', '0.102.0')).toEqual([
+      `${baseURL}/hugo_0.102.0_macOS-universal.tar.gz`,
+      `${baseURL}/hugo_0.102.0_macOS-universal.zip`,
+      `${baseURL}/hugo_0.102.0_macOS-all.tar.gz`,
+      `${baseURL}/hugo_0.102.0_darwin-universal.tar.gz`,
+      `${baseURL}/hugo_0.102.0_darwin-universal.pkg`,
+      `${baseURL}/hugo_v0.102.0_macOS-universal.tar.gz`,
+      `${baseURL}/hugo_v0.102.0_macOS-universal.zip`,
+      `${baseURL}/hugo_v0.102.0_macOS-all.tar.gz`,
+      `${baseURL}/hugo_v0.102.0_darwin-universal.tar.gz`,
+      `${baseURL}/hugo_v0.102.0_darwin-universal.pkg`
+    ]);
+  });
+
+  test('get URLs to darwin assets', () => {
+    const baseURL = 'https://github.com/gohugoio/hugo/releases/download/v0.103.0';
+    expect(getURL('darwin', 'universal', 'false', '0.103.0')).toEqual([
+      `${baseURL}/hugo_0.103.0_darwin-universal.tar.gz`,
+      `${baseURL}/hugo_0.103.0_darwin-universal.pkg`,
+      `${baseURL}/hugo_v0.103.0_darwin-universal.tar.gz`,
+      `${baseURL}/hugo_v0.103.0_darwin-universal.pkg`
+    ]);
+  });
+
   test('get URLs to legacy macOS assets', () => {
     const baseURL = 'https://github.com/gohugoio/hugo/releases/download/v0.20.2';
     expect(getURL('macOS', '64bit', 'false', '0.20.2')).toEqual([
@@ -81,6 +107,16 @@ describe('getURL()', () => {
     ]);
   });
 
+  test('get URLs to downcased Windows assets', () => {
+    const baseURL = 'https://github.com/gohugoio/hugo/releases/download/v0.103.0';
+    expect(getURL('windows', 'amd64', 'false', '0.103.0')).toEqual([
+      `${baseURL}/hugo_0.103.0_windows-amd64.zip`,
+      `${baseURL}/hugo_0.103.0_Windows-amd64.zip`,
+      `${baseURL}/hugo_v0.103.0_windows-amd64.zip`,
+      `${baseURL}/hugo_v0.103.0_Windows-amd64.zip`
+    ]);
+  });
+
   test('get URLs to legacy Windows assets', () => {
     const baseURL = 'https://github.com/gohugoio/hugo/releases/download/v0.20.3';
     expect(getURL('Windows', '64bit', 'false', '0.20.3')).toEqual([
@@ -88,6 +124,18 @@ describe('getURL()', () => {
       `${baseURL}/hugo_0.20.3_windows-amd64.zip`,
       `${baseURL}/hugo_v0.20.3_Windows-64bit.zip`,
       `${baseURL}/hugo_v0.20.3_windows-amd64.zip`
+    ]);
+  });
+
+  test('get URLs to downcased Linux assets', () => {
+    const baseURL = 'https://github.com/gohugoio/hugo/releases/download/v0.103.0';
+    expect(getURL('linux', 'arm', 'false', '0.103.0')).toEqual([
+      `${baseURL}/hugo_0.103.0_linux-arm.tar.gz`,
+      `${baseURL}/hugo_0.103.0_Linux-arm.tar.gz`,
+      `${baseURL}/hugo_0.103.0_Linux_arm.tar.gz`,
+      `${baseURL}/hugo_v0.103.0_linux-arm.tar.gz`,
+      `${baseURL}/hugo_v0.103.0_Linux-arm.tar.gz`,
+      `${baseURL}/hugo_v0.103.0_Linux_arm.tar.gz`
     ]);
   });
 

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1,9 +1,9 @@
 import * as main from '../src/main';
 import * as io from '@actions/io';
 import path from 'path';
-import nock from 'nock';
 import {Tool, Action} from '../src/constants';
 import {FetchError} from 'node-fetch';
+import {clearMockFetchResponses, mockFetchResponse} from './mocks/node-fetch';
 import jsonTestBrew from './data/brew.json';
 // import jsonTestGithub from './data/github.json';
 
@@ -20,7 +20,7 @@ describe('Integration testing run()', () => {
 
     delete process.env['INPUT_HUGO-VERSION'];
     delete process.env['INPUT_EXTENDED'];
-    nock.cleanAll();
+    clearMockFetchResponses();
   });
 
   test('succeed in installing a custom version', async () => {
@@ -44,7 +44,7 @@ describe('Integration testing run()', () => {
   test('succeed in installing the latest version', async () => {
     const testVersion = 'latest';
     process.env['INPUT_HUGO-VERSION'] = testVersion;
-    nock('https://formulae.brew.sh').get(`/api/formula/${Tool.Repo}.json`).reply(200, jsonTestBrew);
+    mockFetchResponse(`https://formulae.brew.sh/api/formula/${Tool.Repo}.json`, 200, jsonTestBrew);
     const result: main.ActionResult = await main.run();
     expect(result.exitcode).toBe(0);
     expect(result.output).toMatch(`hugo v${Tool.TestVersionLatest}`);
@@ -54,7 +54,7 @@ describe('Integration testing run()', () => {
     const testVersion = 'latest';
     process.env['INPUT_HUGO-VERSION'] = testVersion;
     process.env['INPUT_EXTENDED'] = 'true';
-    nock('https://formulae.brew.sh').get(`/api/formula/${Tool.Repo}.json`).reply(200, jsonTestBrew);
+    mockFetchResponse(`https://formulae.brew.sh/api/formula/${Tool.Repo}.json`, 200, jsonTestBrew);
     const result: main.ActionResult = await main.run();
     expect(result.exitcode).toBe(0);
     expect(result.output).toMatch(`hugo v${Tool.TestVersionLatest}`);
@@ -63,7 +63,7 @@ describe('Integration testing run()', () => {
 
   test('fail to install the latest version due to 404 of brew', async () => {
     process.env['INPUT_HUGO-VERSION'] = 'latest';
-    nock('https://formulae.brew.sh').get(`/api/formula/${Tool.Repo}.json`).reply(404);
+    mockFetchResponse(`https://formulae.brew.sh/api/formula/${Tool.Repo}.json`, 404);
 
     await expect(main.run()).rejects.toThrow(FetchError);
   });

--- a/__tests__/mocks/node-fetch.ts
+++ b/__tests__/mocks/node-fetch.ts
@@ -22,8 +22,35 @@ interface ResponseLike {
   json: () => Promise<unknown>;
 }
 
+interface MockResponse {
+  body?: unknown;
+  status: number;
+}
+
+const mockResponses = new Map<string, MockResponse>();
+
+export function mockFetchResponse(url: string, status: number, body?: unknown): void {
+  mockResponses.set(url, {
+    body,
+    status
+  });
+}
+
+export function clearMockFetchResponses(): void {
+  mockResponses.clear();
+}
+
 export default async function fetch(url: string | URL): Promise<ResponseLike> {
   const target = url.toString();
+  const mockResponse = mockResponses.get(target);
+  if (mockResponse) {
+    return {
+      ok: mockResponse.status >= 200 && mockResponse.status < 300,
+      status: mockResponse.status,
+      json: async () => mockResponse.body as unknown
+    };
+  }
+
   const client = target.startsWith('https:') ? https : http;
 
   return new Promise((resolve, reject) => {

--- a/src/get-arch.ts
+++ b/src/get-arch.ts
@@ -1,11 +1,32 @@
-export default function getArch(arch: string): string {
+export default function getArch(arch: string, os: string, version: string): string {
+  const segments = version.split('.').map(s => parseInt(s));
+
+  if (os == 'darwin' || (os == 'macOS' && segments[0] >= 0 && segments[1] >= 102)) {
+    return 'universal'
+  }
+
+  if (segments[0] >= 0 && segments[1] >= 103) {
+    switch (arch) {
+      case 'x64':
+        return 'amd64';
+      case 'arm64':
+        return 'arm64';
+      default:
+        throw new Error(`${arch} is not supported`);
+    }
+  }
+
   switch (arch) {
     case 'x64':
-      return '64bit';
+      return (segments[0] >= 0 && segments[1] >= 103) ? 'amd64' : '64bit';
     case 'arm':
-      return 'ARM';
+      if (segments[0] >= 0 && segments[1] < 102) {
+        return 'ARM';
+      } else {
+        throw new Error(`${arch} is not supported`);
+      }
     case 'arm64':
-      return 'ARM64';
+      return (segments[0] >= 0 && segments[1] >= 103) ? 'arm64' : 'ARM64';
     default:
       throw new Error(`${arch} is not supported`);
   }

--- a/src/get-arch.ts
+++ b/src/get-arch.ts
@@ -1,7 +1,7 @@
 import {conventions} from './get-conventions';
 
 export default function getArch(arch: string, os: string, conventions: conventions): string {
-  if (os === 'darwin' || (os === 'macOS' && conventions.arch.darwinUniversal)) {
+  if (conventions.arch.darwinUniversal && (os === 'darwin' || os === 'macOS')) {
     return 'universal';
   }
 

--- a/src/get-arch.ts
+++ b/src/get-arch.ts
@@ -1,7 +1,7 @@
 import {conventions} from './get-conventions';
 
 export default function getArch(arch: string, os: string, conventions: conventions): string {
-  if (os == 'darwin' || (os == 'macOS' && conventions.arch.darwinUniversal)) {
+  if (os === 'darwin' || (os === 'macOS' && conventions.arch.darwinUniversal)) {
     return 'universal';
   }
 
@@ -9,11 +9,11 @@ export default function getArch(arch: string, os: string, conventions: conventio
     case 'x64':
       return conventions.arch.standardizedNaming ? 'amd64' : '64bit';
     case 'arm':
-      if (conventions.arch.dropped32BitSupport) {
+      if (conventions.arch.droppedWindowsArmSupport && (os === 'Windows' || os === 'windows')) {
         throw new Error(`${arch} is not supported`);
       }
 
-      return 'ARM';
+      return conventions.arch.standardizedNaming ? 'arm' : 'ARM';
     case 'arm64':
       return conventions.arch.standardizedNaming ? 'arm64' : 'ARM64';
     default:

--- a/src/get-arch.ts
+++ b/src/get-arch.ts
@@ -1,32 +1,21 @@
-export default function getArch(arch: string, os: string, version: string): string {
-  const segments = version.split('.').map(s => parseInt(s));
+import {conventions} from './get-conventions';
 
-  if (os == 'darwin' || (os == 'macOS' && segments[0] >= 0 && segments[1] >= 102)) {
-    return 'universal'
-  }
-
-  if (segments[0] >= 0 && segments[1] >= 103) {
-    switch (arch) {
-      case 'x64':
-        return 'amd64';
-      case 'arm64':
-        return 'arm64';
-      default:
-        throw new Error(`${arch} is not supported`);
-    }
+export default function getArch(arch: string, os: string, conventions: conventions): string {
+  if (os == 'darwin' || (os == 'macOS' && conventions.arch.darwinUniversal)) {
+    return 'universal';
   }
 
   switch (arch) {
     case 'x64':
-      return (segments[0] >= 0 && segments[1] >= 103) ? 'amd64' : '64bit';
+      return conventions.arch.standardizedNaming ? 'amd64' : '64bit';
     case 'arm':
-      if (segments[0] >= 0 && segments[1] < 102) {
-        return 'ARM';
-      } else {
+      if (conventions.arch.dropped32BitSupport) {
         throw new Error(`${arch} is not supported`);
       }
+
+      return 'ARM';
     case 'arm64':
-      return (segments[0] >= 0 && segments[1] >= 103) ? 'arm64' : 'ARM64';
+      return conventions.arch.standardizedNaming ? 'arm64' : 'ARM64';
     default:
       throw new Error(`${arch} is not supported`);
   }

--- a/src/get-conventions.ts
+++ b/src/get-conventions.ts
@@ -10,7 +10,7 @@ export interface conventions {
   };
 }
 
-export default function getConventions(version: string): conventions {
+export function getConventions(version: string): conventions {
   const segments = version.split('.').map(s => parseInt(s));
   const stableOrNewer = segments[0] > 0;
   const newerThan103 = stableOrNewer || segments[1] >= 103;

--- a/src/get-conventions.ts
+++ b/src/get-conventions.ts
@@ -1,0 +1,29 @@
+export interface conventions {
+  arch: {
+    darwinUniversal: boolean;
+    dropped32BitSupport: boolean;
+    standardizedNaming: boolean;
+  };
+  os: {
+    renamedMacOS: boolean;
+    downcasedAll: boolean;
+  };
+}
+
+export default function getConventions(version: string): conventions {
+  const segments = version.split('.').map(s => parseInt(s));
+  const stableOrNewer = segments[0] > 0;
+  const newerThan103 = stableOrNewer || segments[1] >= 103;
+  const newerThan102 = stableOrNewer || segments[1] >= 102;
+  return {
+    arch: {
+      darwinUniversal: newerThan102,
+      dropped32BitSupport: newerThan102,
+      standardizedNaming: newerThan103
+    },
+    os: {
+      renamedMacOS: newerThan102,
+      downcasedAll: newerThan103
+    }
+  };
+}

--- a/src/get-conventions.ts
+++ b/src/get-conventions.ts
@@ -1,7 +1,7 @@
 export interface conventions {
   arch: {
     darwinUniversal: boolean;
-    dropped32BitSupport: boolean;
+    droppedWindowsArmSupport: boolean;
     standardizedNaming: boolean;
   };
   os: {
@@ -18,11 +18,11 @@ export default function getConventions(version: string): conventions {
   return {
     arch: {
       darwinUniversal: newerThan102,
-      dropped32BitSupport: newerThan102,
+      droppedWindowsArmSupport: newerThan102,
       standardizedNaming: newerThan103
     },
     os: {
-      renamedMacOS: newerThan102,
+      renamedMacOS: newerThan103,
       downcasedAll: newerThan103
     }
   };

--- a/src/get-os.ts
+++ b/src/get-os.ts
@@ -1,11 +1,12 @@
-export default function getOS(platform: string): string {
+export default function getOS(platform: string, version: string): string {
+  const segments = version.split('.').map(s => parseInt(s));
   switch (platform) {
     case 'linux':
-      return 'Linux';
+      return (segments[0] >= 0 && segments[1] >= 103) ? 'linux' : 'Linux'
     case 'darwin':
-      return 'macOS';
+      return (segments[0] >= 0 && segments[1] >= 102) ? 'darwin' : 'macOS'
     case 'win32':
-      return 'Windows';
+      return (segments[0] >= 0 && segments[1] >= 103) ? 'windows' : 'Windows'
     default:
       throw new Error(`${platform} is not supported`);
   }

--- a/src/get-os.ts
+++ b/src/get-os.ts
@@ -1,12 +1,13 @@
-export default function getOS(platform: string, version: string): string {
-  const segments = version.split('.').map(s => parseInt(s));
+import {conventions} from './get-conventions';
+
+export default function getOS(platform: string, conventions: conventions): string {
   switch (platform) {
     case 'linux':
-      return (segments[0] >= 0 && segments[1] >= 103) ? 'linux' : 'Linux'
+      return conventions.os.downcasedAll ? 'linux' : 'Linux';
     case 'darwin':
-      return (segments[0] >= 0 && segments[1] >= 102) ? 'darwin' : 'macOS'
+      return conventions.os.renamedMacOS ? 'darwin' : 'macOS';
     case 'win32':
-      return (segments[0] >= 0 && segments[1] >= 103) ? 'windows' : 'Windows'
+      return conventions.os.downcasedAll ? 'windows' : 'Windows';
     default:
       throw new Error(`${platform} is not supported`);
   }

--- a/src/get-url.ts
+++ b/src/get-url.ts
@@ -49,22 +49,34 @@ export default function getURL(
     );
   }
 
-  if (os === 'Windows') {
+  if (os === 'darwin') {
     return assetURLs(
       assetBases.flatMap(assetBase => [
-        `${assetBase}Windows-${arch}.zip`,
-        `${assetBase}windows-${lowerArch(arch)}.zip`
+        `${assetBase}darwin-${arch}.tar.gz`,
+        `${assetBase}darwin-${arch}.pkg`
       ])
     );
   }
 
-  if (os === 'Linux') {
+  if (os === 'Windows' || os === 'windows') {
+    const assetPatterns =
+      os === 'windows'
+        ? [`windows-${lowerArch(arch)}.zip`, `Windows-${arch}.zip`]
+        : [`Windows-${arch}.zip`, `windows-${lowerArch(arch)}.zip`];
+
     return assetURLs(
-      assetBases.flatMap(assetBase => [
-        `${assetBase}Linux-${arch}.tar.gz`,
-        `${assetBase}Linux_${arch}.tar.gz`,
-        `${assetBase}linux-${lowerArch(arch)}.tar.gz`
-      ])
+      assetBases.flatMap(assetBase => assetPatterns.map(asset => `${assetBase}${asset}`))
+    );
+  }
+
+  if (os === 'Linux' || os === 'linux') {
+    const assetPatterns =
+      os === 'linux'
+        ? [`linux-${lowerArch(arch)}.tar.gz`, `Linux-${arch}.tar.gz`, `Linux_${arch}.tar.gz`]
+        : [`Linux-${arch}.tar.gz`, `Linux_${arch}.tar.gz`, `linux-${lowerArch(arch)}.tar.gz`];
+
+    return assetURLs(
+      assetBases.flatMap(assetBase => assetPatterns.map(asset => `${assetBase}${asset}`))
     );
   }
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -2,7 +2,7 @@ import * as core from '@actions/core';
 import * as tc from '@actions/tool-cache';
 import * as io from '@actions/io';
 import * as exec from '@actions/exec';
-import getConventions from './get-conventions';
+import {getConventions} from './get-conventions';
 import getOS from './get-os';
 import getArch from './get-arch';
 import getURL from './get-url';

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -2,6 +2,7 @@ import * as core from '@actions/core';
 import * as tc from '@actions/tool-cache';
 import * as io from '@actions/io';
 import * as exec from '@actions/exec';
+import getConventions from './get-conventions';
 import getOS from './get-os';
 import getArch from './get-arch';
 import getURL from './get-url';
@@ -113,10 +114,12 @@ export async function installer(version: string): Promise<void> {
   const extended: string = core.getInput('extended');
   core.debug(`Hugo extended: ${extended}`);
 
-  const osName: string = getOS(process.platform, version);
+  const conventions = getConventions(version);
+
+  const osName: string = getOS(process.platform, conventions);
   core.debug(`Operating System: ${osName}`);
 
-  const archName: string = getArch(process.arch, osName, version);
+  const archName: string = getArch(process.arch, osName, conventions);
   core.debug(`Processor Architecture: ${archName}`);
 
   const toolURLs: string[] = getURL(osName, archName, extended, version);

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -113,10 +113,10 @@ export async function installer(version: string): Promise<void> {
   const extended: string = core.getInput('extended');
   core.debug(`Hugo extended: ${extended}`);
 
-  const osName: string = getOS(process.platform);
+  const osName: string = getOS(process.platform, version);
   core.debug(`Operating System: ${osName}`);
 
-  const archName: string = getArch(process.arch);
+  const archName: string = getArch(process.arch, osName, version);
   core.debug(`Processor Architecture: ${archName}`);
 
   const toolURLs: string[] = getURL(osName, archName, extended, version);


### PR DESCRIPTION
## Summary

Rebases the Hugo package naming fix from #609 on top of the current `main` branch, including the installer flow added in #687.

- Derive Hugo release asset OS and architecture naming conventions from the requested Hugo version.
- Apply those conventions when selecting OS and architecture segments, including the 0.102.x macOS universal boundary, 0.103+ downcased OS names, Windows zip assets, and Linux ARM assets.
- Add table-driven tests for pre-0.102, 0.102.x, and 0.103+ naming behavior, plus URL coverage for the corrected release asset names.

## Changes

- Add `getConventions` to centralize version-based release asset naming decisions.
- Update `getOS` and `getArch` to use convention flags for macOS, lower-case OS names, standardized architecture names, and the Windows ARM support boundary.
- Update `getURL` to generate candidate URLs for downcased Windows and Linux assets, and for darwin universal archives.
- Wire convention detection into `installer` before generating candidate Hugo release asset URLs.
- Expand unit coverage for OS, architecture, convention, and URL behavior.

## Checklist

- [x] I have read the latest README and followed the instructions.
- [x] I have added or updated tests for behavior changes.
- [x] README.md and action.yml updates are not needed because inputs and action metadata are unchanged.
- [x] I have run the relevant verification commands.

## References

- Rebased follow-up for https://github.com/peaceiris/actions-hugo/pull/609
- References https://github.com/peaceiris/actions-hugo/issues/605 and https://github.com/peaceiris/actions-hugo/issues/608
- Based on `main` after https://github.com/peaceiris/actions-hugo/pull/687

## Verification

- [x] `RUNNER_TEMP=/private/tmp npm run all`
- [ ] `npm run build` was not run because this branch does not update bundled output and current `main` removed `lib/index.js`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Version-aware conventions control OS and architecture naming, including macOS universal asset support and expanded darwin/macOS patterns.

* **Refactor**
  * Conventions centralized and applied across installer and URL generation; OS/arch inputs accept varied casing and naming variants.

* **Tests**
  * Expanded, data-driven parameterized tests for conventions, OS/arch mappings, URL variants, and error cases.
  * Replaced network stubs with deterministic fetch-mock helpers for test isolation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/peaceiris/actions-hugo/pull/688)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->