### PR TITLE
Handle Hugo 0.139.5 archive fallback

### DIFF
--- a/__tests__/get-url.test.ts
+++ b/__tests__/get-url.test.ts
@@ -1,4 +1,4 @@
-import getURL from '../src/get-url';
+import getURL, {getDownloadVersion} from '../src/get-url';
 
 describe('getURL()', () => {
   test('get URLs to Linux assets', () => {
@@ -136,6 +136,19 @@ describe('getURL()', () => {
       `${baseURL}/hugo_v0.103.0_linux-arm.tar.gz`,
       `${baseURL}/hugo_v0.103.0_Linux-arm.tar.gz`,
       `${baseURL}/hugo_v0.103.0_Linux_arm.tar.gz`
+    ]);
+  });
+
+  test('get URLs to Hugo 0.139.5 archive alias', () => {
+    const baseURL = 'https://github.com/gohugoio/hugo/releases/download/v0.139.4';
+    expect(getDownloadVersion('0.139.5')).toBe('0.139.4');
+    expect(getURL('linux', 'amd64', 'true', '0.139.5')).toEqual([
+      `${baseURL}/hugo_extended_0.139.4_linux-amd64.tar.gz`,
+      `${baseURL}/hugo_extended_0.139.4_Linux-amd64.tar.gz`,
+      `${baseURL}/hugo_extended_0.139.4_Linux_amd64.tar.gz`,
+      `${baseURL}/hugo_extended_v0.139.4_linux-amd64.tar.gz`,
+      `${baseURL}/hugo_extended_v0.139.4_Linux-amd64.tar.gz`,
+      `${baseURL}/hugo_extended_v0.139.4_Linux_amd64.tar.gz`
     ]);
   });
 

--- a/src/get-url.ts
+++ b/src/get-url.ts
@@ -4,6 +4,8 @@ export default function getURL(
   extended: string,
   version: string
 ): string[] {
+  const downloadVersion = getDownloadVersion(version);
+
   const extendedStr = (extended: string): string => {
     if (extended === 'true') {
       return 'extended_';
@@ -28,12 +30,12 @@ export default function getURL(
   };
 
   const baseURL = 'https://github.com/gohugoio/hugo/releases/download';
-  const assetBase = `hugo_${extendedStr(extended)}${version}_`;
-  const legacyVersionedAssetBase = `hugo_${extendedStr(extended)}v${version}_`;
+  const assetBase = `hugo_${extendedStr(extended)}${downloadVersion}_`;
+  const legacyVersionedAssetBase = `hugo_${extendedStr(extended)}v${downloadVersion}_`;
   const assetBases = [assetBase, legacyVersionedAssetBase];
   const assetURLs = (assetNames: string[]): string[] => {
     return Array.from(new Set(assetNames)).map(assetName => {
-      return `${baseURL}/v${version}/${assetName}`;
+      return `${baseURL}/v${downloadVersion}/${assetName}`;
     });
   };
 
@@ -81,4 +83,13 @@ export default function getURL(
   }
 
   return assetURLs([`${assetBase}${os}-${arch}.tar.gz`]);
+}
+
+export function getDownloadVersion(version: string): string {
+  if (version === '0.139.5') {
+    // v0.139.5 has no release archives; Hugo publishes the same archives under v0.139.4.
+    return '0.139.4';
+  }
+
+  return version;
 }

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -5,7 +5,7 @@ import * as exec from '@actions/exec';
 import {getConventions} from './get-conventions';
 import getOS from './get-os';
 import getArch from './get-arch';
-import getURL from './get-url';
+import getURL, {getDownloadVersion} from './get-url';
 import * as path from 'path';
 import {Tool, Action} from './constants';
 
@@ -123,6 +123,12 @@ export async function installer(version: string): Promise<void> {
   core.debug(`Processor Architecture: ${archName}`);
 
   const toolURLs: string[] = getURL(osName, archName, extended, version);
+  const downloadVersion = getDownloadVersion(version);
+  if (downloadVersion !== version) {
+    core.info(
+      `Hugo ${version} release does not publish archives; downloading v${downloadVersion} archives instead.`
+    );
+  }
 
   const workDir = await createWorkDir();
   const binDir = await createBinDir(workDir);


### PR DESCRIPTION
## 概要
- Add a download-version alias so Hugo 0.139.5 downloads use the v0.139.4 release archives.
- Log when an archive alias is used and cover the Linux extended URL generation with a unit test.

## 参考
- Hugo v0.139.5 publishes no release assets and points users to the v0.139.4 release archives.
- Related: https://github.com/gohugoio/hugo/issues/13147

## Test plan
- [x] npm run format:check
- [x] npm run lint
- [x] npm test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Version 0.139.5 now correctly downloads as 0.139.4 due to archive naming compatibility. An informational message notifies users when an alternative version is downloaded.

* **Tests**
  * Added test coverage for version aliasing behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/peaceiris/actions-hugo/pull/696)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->