### PR TITLE
feat: verify the SHA-256 checksum of the downloaded archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Thanks to this change, we can complete this action in less than a few seconds.
 - [Options](#options)
   - [⭐️ Use Hugo extended](#%EF%B8%8F-use-hugo-extended)
   - [⭐️ Use the latest version of Hugo](#%EF%B8%8F-use-the-latest-version-of-hugo)
+  - [⭐️ Verify the archive checksum](#%EF%B8%8F-verify-the-archive-checksum)
 - [Tips](#tips)
   - [⭐️ Caching Hugo Modules](#%EF%B8%8F-caching-hugo-modules)
   - [⭐️ Read Hugo version from file](#%EF%B8%8F-read-hugo-version-from-file)
@@ -138,7 +139,22 @@ Set `hugo-version: 'latest'` to use the latest version of Hugo.
     hugo-version: 'latest'
 ```
 
-This action fetches the latest version of Hugo by [hugo | Homebrew Formulae](https://formulae.brew.sh/formula/hugo)
+### ⭐️ Verify the archive checksum
+
+By default, the action verifies the SHA-256 checksum of the downloaded Hugo archive against the `hugo_X.Y.Z_checksums.txt` file published with the release, and fails before extraction if they do not match. If the release has no checksums file or the archive is not listed in it, the action logs a warning and skips verification.
+
+To also protect against the release assets themselves being replaced (GitHub release assets are mutable), set `sha256` to pin the expected checksum of the archive:
+
+```yaml
+- name: Setup Hugo
+  uses: peaceiris/actions-hugo@v3
+  with:
+    hugo-version: '0.158.0'
+    extended: true
+    sha256: 'c2a724ac3c8e949fca56dd438b868b2128837754420c20a6e7ae345616c4e625'
+```
+
+Take the value from the `hugo_X.Y.Z_checksums.txt` file on the [Hugo release page](https://github.com/gohugoio/hugo/releases) for the archive that matches your runner's OS and architecture (the example above is `hugo_extended_0.158.0_linux-amd64.tar.gz`). Note that the pinned checksum is OS/arch-specific, so a matrix build needs a different `sha256` per runner, and combining `sha256` with `hugo-version: 'latest'` will fail as soon as a new Hugo version is released.
 
 <div align="right">
 <a href="#table-of-contents">Back to TOC ☝️</a>

--- a/__tests__/mocks/actions-core.ts
+++ b/__tests__/mocks/actions-core.ts
@@ -15,3 +15,7 @@ export function debug(message: string): void {
 export function info(message: string): void {
   void message;
 }
+
+export function warning(message: string): void {
+  void message;
+}

--- a/__tests__/mocks/node-fetch.ts
+++ b/__tests__/mocks/node-fetch.ts
@@ -20,6 +20,7 @@ interface ResponseLike {
   ok: boolean;
   status: number;
   json: () => Promise<unknown>;
+  text: () => Promise<string>;
 }
 
 interface MockResponse {
@@ -47,7 +48,8 @@ export default async function fetch(url: string | URL): Promise<ResponseLike> {
     return {
       ok: mockResponse.status >= 200 && mockResponse.status < 300,
       status: mockResponse.status,
-      json: async () => mockResponse.body as unknown
+      json: async () => mockResponse.body as unknown,
+      text: async () => `${mockResponse.body ?? ''}`
     };
   }
 
@@ -68,7 +70,8 @@ export default async function fetch(url: string | URL): Promise<ResponseLike> {
         resolve({
           ok: status >= 200 && status < 300,
           status,
-          json: async () => JSON.parse(body) as unknown
+          json: async () => JSON.parse(body) as unknown,
+          text: async () => body
         });
       });
     });

--- a/__tests__/mocks/node-fetch.ts
+++ b/__tests__/mocks/node-fetch.ts
@@ -29,6 +29,7 @@ interface MockResponse {
 }
 
 const mockResponses = new Map<string, MockResponse>();
+const mockErrors = new Map<string, Error>();
 
 export function mockFetchResponse(url: string, status: number, body?: unknown): void {
   mockResponses.set(url, {
@@ -37,12 +38,22 @@ export function mockFetchResponse(url: string, status: number, body?: unknown): 
   });
 }
 
+export function mockFetchError(url: string, error: Error): void {
+  mockErrors.set(url, error);
+}
+
 export function clearMockFetchResponses(): void {
   mockResponses.clear();
+  mockErrors.clear();
 }
 
 export default async function fetch(url: string | URL): Promise<ResponseLike> {
   const target = url.toString();
+  const mockError = mockErrors.get(target);
+  if (mockError) {
+    throw mockError;
+  }
+
   const mockResponse = mockResponses.get(target);
   if (mockResponse) {
     return {

--- a/__tests__/verify-checksum.test.ts
+++ b/__tests__/verify-checksum.test.ts
@@ -2,7 +2,7 @@ import * as core from '@actions/core';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import {clearMockFetchResponses, mockFetchResponse} from './mocks/node-fetch';
+import {clearMockFetchResponses, mockFetchError, mockFetchResponse} from './mocks/node-fetch';
 import {
   computeSHA256,
   fetchReleaseChecksum,
@@ -79,6 +79,15 @@ describe('verify-checksum', () => {
       expect(await fetchReleaseChecksum('0.158.0', assetURL)).toBe('');
       expect(core.warning).toHaveBeenCalledWith(
         `request to ${checksumsURL} failed with status 404`
+      );
+    });
+
+    test('warn and return an empty string when the fetch throws', async () => {
+      mockFetchError(checksumsURL, new Error('socket hang up'));
+
+      expect(await fetchReleaseChecksum('0.158.0', assetURL)).toBe('');
+      expect(core.warning).toHaveBeenCalledWith(
+        `request to ${checksumsURL} failed: Error: socket hang up`
       );
     });
 

--- a/__tests__/verify-checksum.test.ts
+++ b/__tests__/verify-checksum.test.ts
@@ -1,0 +1,130 @@
+import * as core from '@actions/core';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {clearMockFetchResponses, mockFetchResponse} from './mocks/node-fetch';
+import {
+  computeSHA256,
+  fetchReleaseChecksum,
+  findChecksum,
+  getChecksumsURL,
+  verifyChecksum
+} from '../src/verify-checksum';
+
+// SHA-256 of the ASCII string 'hello world'
+const helloWorldSHA256 = 'b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9';
+
+const checksumsURL =
+  'https://github.com/gohugoio/hugo/releases/download/v0.158.0/hugo_0.158.0_checksums.txt';
+const assetURL =
+  'https://github.com/gohugoio/hugo/releases/download/v0.158.0/hugo_extended_0.158.0_linux-amd64.tar.gz';
+const checksumsText = [
+  '1111111111111111111111111111111111111111111111111111111111111111  hugo_0.158.0_linux-amd64.tar.gz',
+  `${helloWorldSHA256}  hugo_extended_0.158.0_linux-amd64.tar.gz`,
+  '2222222222222222222222222222222222222222222222222222222222222222  hugo_extended_0.158.0_windows-amd64.zip'
+].join('\n');
+
+describe('verify-checksum', () => {
+  let tempDir = '';
+  let filePath = '';
+
+  beforeAll(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'verify-checksum-'));
+    filePath = path.join(tempDir, 'asset.tar.gz');
+    fs.writeFileSync(filePath, 'hello world');
+  });
+
+  afterAll(() => {
+    fs.rmSync(tempDir, {recursive: true, force: true});
+  });
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.spyOn(core, 'info').mockImplementation(jest.fn());
+    jest.spyOn(core, 'warning').mockImplementation(jest.fn());
+  });
+
+  afterEach(() => {
+    clearMockFetchResponses();
+  });
+
+  describe('getChecksumsURL()', () => {
+    test('return the checksums file URL of a release', () => {
+      expect(getChecksumsURL('0.158.0')).toBe(checksumsURL);
+    });
+  });
+
+  describe('findChecksum()', () => {
+    test('return the checksum of the given asset', () => {
+      expect(findChecksum(checksumsText, 'hugo_extended_0.158.0_linux-amd64.tar.gz')).toBe(
+        helloWorldSHA256
+      );
+    });
+
+    test('return an empty string when the asset is not listed', () => {
+      expect(findChecksum(checksumsText, 'hugo_extended_0.158.0_darwin-universal.pkg')).toBe('');
+    });
+  });
+
+  describe('fetchReleaseChecksum()', () => {
+    test('return the checksum of the downloaded asset', async () => {
+      mockFetchResponse(checksumsURL, 200, checksumsText);
+
+      expect(await fetchReleaseChecksum('0.158.0', assetURL)).toBe(helloWorldSHA256);
+    });
+
+    test('warn and return an empty string when the checksums file is missing', async () => {
+      mockFetchResponse(checksumsURL, 404);
+
+      expect(await fetchReleaseChecksum('0.158.0', assetURL)).toBe('');
+      expect(core.warning).toHaveBeenCalledWith(
+        `request to ${checksumsURL} failed with status 404`
+      );
+    });
+
+    test('warn and return an empty string when the asset is not listed', async () => {
+      mockFetchResponse(checksumsURL, 200, checksumsText);
+      const pkgAssetURL =
+        'https://github.com/gohugoio/hugo/releases/download/v0.158.0/hugo_extended_0.158.0_darwin-universal.pkg';
+
+      expect(await fetchReleaseChecksum('0.158.0', pkgAssetURL)).toBe('');
+      expect(core.warning).toHaveBeenCalledWith(
+        `no SHA-256 checksum for hugo_extended_0.158.0_darwin-universal.pkg found in ${checksumsURL}`
+      );
+    });
+  });
+
+  describe('computeSHA256()', () => {
+    test('compute the SHA-256 checksum of a file', async () => {
+      expect(await computeSHA256(filePath)).toBe(helloWorldSHA256);
+    });
+  });
+
+  describe('verifyChecksum()', () => {
+    test('pass when the checksum matches', async () => {
+      await expect(
+        verifyChecksum(filePath, 'https://example.com/hugo.tar.gz', helloWorldSHA256)
+      ).resolves.toBeUndefined();
+    });
+
+    test('ignore case and surrounding whitespace in the expected checksum', async () => {
+      await expect(
+        verifyChecksum(
+          filePath,
+          'https://example.com/hugo.tar.gz',
+          ` ${helloWorldSHA256.toUpperCase()} `
+        )
+      ).resolves.toBeUndefined();
+    });
+
+    test('throw a clear error when the checksum does not match', async () => {
+      const wrongSHA256 = 'a'.repeat(64);
+
+      await expect(
+        verifyChecksum(filePath, 'https://example.com/hugo.tar.gz', wrongSHA256)
+      ).rejects.toThrow(
+        `SHA-256 checksum mismatch for https://example.com/hugo.tar.gz (expected: ${wrongSHA256}, actual: ${helloWorldSHA256})`
+      );
+    });
+  });
+});

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: 'Download (if necessary) and use Hugo extended version. Example: true'
     required: false
     default: 'false'
+  sha256:
+    description: 'Pin the expected SHA-256 checksum of the downloaded Hugo archive. By default, the archive is verified against the hugo_X.Y.Z_checksums.txt file of the release. Example: c2a724ac3c8e949fca56dd438b868b2128837754420c20a6e7ae345616c4e625'
+    required: false
+    default: ''
 runs:
   using: 'node24'
   main: 'lib/index.js'

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -6,6 +6,7 @@ import {getConventions} from './get-conventions';
 import getOS from './get-os';
 import getArch from './get-arch';
 import getURL, {getDownloadVersion} from './get-url';
+import {fetchReleaseChecksum, verifyChecksum} from './verify-checksum';
 import * as path from 'path';
 import {Tool, Action} from './constants';
 
@@ -114,6 +115,8 @@ export async function installer(version: string): Promise<void> {
   const extended: string = core.getInput('extended');
   core.debug(`Hugo extended: ${extended}`);
 
+  const expectedSHA256: string = core.getInput('sha256');
+
   const conventions = getConventions(version);
 
   const osName: string = getOS(process.platform, conventions);
@@ -135,5 +138,15 @@ export async function installer(version: string): Promise<void> {
   const tempDir = await createTempDir(workDir);
 
   const toolAsset: DownloadedAsset = await downloadHugoAsset(toolURLs);
+  if (expectedSHA256 !== '') {
+    await verifyChecksum(toolAsset.path, toolAsset.url, expectedSHA256);
+  } else {
+    const releaseSHA256 = await fetchReleaseChecksum(downloadVersion, toolAsset.url);
+    if (releaseSHA256 === '') {
+      core.warning('skipping SHA-256 checksum verification');
+    } else {
+      await verifyChecksum(toolAsset.path, toolAsset.url, releaseSHA256);
+    }
+  }
   await extractHugoAsset(toolAsset.path, toolAsset.url, tempDir, binDir);
 }

--- a/src/verify-checksum.ts
+++ b/src/verify-checksum.ts
@@ -19,13 +19,17 @@ export function findChecksum(checksumsText: string, assetName: string): string {
   return '';
 }
 
+export const FetchChecksumsTimeoutMs = 10000;
+
 export async function fetchReleaseChecksum(version: string, assetURL: string): Promise<string> {
   const checksumsURL = getChecksumsURL(version);
   const assetName = assetURL.substring(assetURL.lastIndexOf('/') + 1);
 
   let checksumsText = '';
   try {
-    const response = await fetch(checksumsURL);
+    const response = await fetch(checksumsURL, {
+      signal: AbortSignal.timeout(FetchChecksumsTimeoutMs)
+    });
     if (!response.ok) {
       core.warning(`request to ${checksumsURL} failed with status ${response.status}`);
       return '';

--- a/src/verify-checksum.ts
+++ b/src/verify-checksum.ts
@@ -1,0 +1,68 @@
+import * as core from '@actions/core';
+import fetch from 'node-fetch';
+import {createHash} from 'crypto';
+import {createReadStream} from 'fs';
+import {pipeline} from 'stream/promises';
+
+export function getChecksumsURL(version: string): string {
+  return `https://github.com/gohugoio/hugo/releases/download/v${version}/hugo_${version}_checksums.txt`;
+}
+
+export function findChecksum(checksumsText: string, assetName: string): string {
+  for (const line of checksumsText.split('\n')) {
+    const [checksum, filename] = line.trim().split(/\s+/);
+    if (filename === assetName && checksum) {
+      return checksum;
+    }
+  }
+
+  return '';
+}
+
+export async function fetchReleaseChecksum(version: string, assetURL: string): Promise<string> {
+  const checksumsURL = getChecksumsURL(version);
+  const assetName = assetURL.substring(assetURL.lastIndexOf('/') + 1);
+
+  let checksumsText = '';
+  try {
+    const response = await fetch(checksumsURL);
+    if (!response.ok) {
+      core.warning(`request to ${checksumsURL} failed with status ${response.status}`);
+      return '';
+    }
+    checksumsText = await response.text();
+  } catch (error) {
+    core.warning(`request to ${checksumsURL} failed: ${error}`);
+    return '';
+  }
+
+  const checksum = findChecksum(checksumsText, assetName);
+  if (checksum === '') {
+    core.warning(`no SHA-256 checksum for ${assetName} found in ${checksumsURL}`);
+  }
+
+  return checksum;
+}
+
+export async function computeSHA256(filePath: string): Promise<string> {
+  const hash = createHash('sha256');
+  await pipeline(createReadStream(filePath), hash);
+  return hash.digest('hex');
+}
+
+export async function verifyChecksum(
+  filePath: string,
+  assetURL: string,
+  expectedSHA256: string
+): Promise<void> {
+  const expected = expectedSHA256.trim().toLowerCase();
+  const actual = await computeSHA256(filePath);
+
+  if (actual !== expected) {
+    throw new Error(
+      `SHA-256 checksum mismatch for ${assetURL} (expected: ${expected}, actual: ${actual})`
+    );
+  }
+
+  core.info(`SHA-256 checksum verified: ${actual}`);
+}


### PR DESCRIPTION
> [!IMPORTANT]
> This PR was written by Claude Code (Fable 5), working interactively with me. I have since manually reviewed every line and I stand behind it as if I had written it myself — review feedback will get the same human treatment. My original goal was just to add checksum pinning to the Hugo download in my own CI workflow; while researching whether that belonged in a reusable action, Claude found #51 and we decided the right place for the fix was upstream, in the action everyone already uses. The [full backstory](https://blog.banasiak.com/2026/07/supply-chain-shenanigans/) is on my blog, if you enjoy that sort of thing.

## Summary

Implements the checksum validation proposed in #51. By default, the action now downloads the `hugo_X.Y.Z_checksums.txt` file published with the release and verifies the downloaded archive against it before extraction — the approach sketched in the issue, implemented with Node's built-in `crypto` module so it runs identically on Linux, macOS, and Windows runners (no `shasum`/`certutil`). An optional `sha256` input additionally lets consumers pin the expected checksum, which also protects against release assets being replaced after pinning (GitHub release assets are mutable).

Closes #51

## Changes

- Verify the downloaded archive against the release's `hugo_X.Y.Z_checksums.txt` by default, failing before extraction on mismatch; if the release has no checksums file (e.g. very old versions) or the archive is not listed in it, log a warning and skip verification so existing workflows keep working
- Add an optional `sha256` input (default `''`) to pin an exact expected checksum; when set it takes precedence over the checksums file
- New `src/verify-checksum.ts` using Node's built-in `crypto` (cross-platform, no subprocesses)
- Unit tests for all new functions; extend the `node-fetch` mock with `text()` and the `@actions/core` mock with `warning()`
- New "Verify the archive checksum" section in README.md and an updated input description in `action.yml`

## Checklist

- [x] I have read the latest README and followed the instructions.
- [x] I have added or updated tests for behavior changes.
- [x] I have updated README.md and action.yml when inputs or runtime behavior changed.
- [x] I have run the relevant verification commands.

## Verification

- [x] `npm run all` — format check, lint, and 85/85 tests pass
- [x] `npm run build` — bundled to a scratch directory (left `lib/` untouched per AGENTS.md) and ran the bundle end-to-end against real releases:
  - v0.158.0 with no inputs: `SHA-256 checksum verified: c2a724ac…` and Hugo installs
  - v0.158.0 with a wrong `sha256`: fails before extraction with `SHA-256 checksum mismatch for <url> (expected: …, actual: …)`
  - v0.17 (2016, no checksums file): warns `request to … failed with status 404`, `skipping SHA-256 checksum verification`, and continues (its subsequent extraction failure reproduces identically on unmodified `main` — pre-existing and unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SHA-256 archive checksum verification, including a `sha256` input to pin the expected checksum.
  * Supports default verification against published release checksums; if unavailable, logs a warning and skips verification.

* **Bug Fixes**
  * Improved handling when checksum retrieval fails or the asset isn’t listed, with clearer warning messages and mismatch reporting.

* **Documentation**
  * Updated README to describe the new “Verify the archive checksum” option, default behavior, example usage, and compatibility notes.

* **Tests**
  * Added Jest coverage for checksum URL generation, checksum lookup, fetch error/timeout behavior, SHA-256 computation, and match/mismatch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
